### PR TITLE
Allow subdomain

### DIFF
--- a/check_process
+++ b/check_process
@@ -9,7 +9,7 @@
 		is_public=1	(PUBLIC|public=1|private=0)
 	; Checks
 		pkg_linter=1
-		setup_sub_dir=0 #Not supported in upstream app
+		setup_sub_dir=1
 		setup_root=1
 		setup_nourl=0
 		setup_private=1

--- a/check_process
+++ b/check_process
@@ -19,7 +19,7 @@
 		backup_restore=1
 		multi_instance=0
 		port_already_use=0 #No port required
-		change_url=0 #not yet done
+		change_url=1
 ;;; Levels
 	# If the level 5 (Package linter) is forced to 1. Please add justifications here.
 	Level 5=auto

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,8 +1,8 @@
 #sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
-location / {
+location __PATH__/ {
 
   # Path to source
-  root __FINALPATH__/ ;
+  alias __FINALPATH__/ ;
 
   # Force usage of https
   if ($scheme = http) {
@@ -11,5 +11,4 @@ location / {
 
   # Include SSOWAT user panel.
   include conf.d/yunohost_panel.conf.inc;
-
 }

--- a/manifest.json
+++ b/manifest.json
@@ -25,11 +25,13 @@
             {
                 "name": "domain",
                 "type": "domain",
-                "help": {
-                    "en": "RetroArch requires its own subdomain",
-                    "fr": "RetroArch nécessite son propre sous-domaine"
-                },
                 "example": "retroarch.example.com"
+            },
+            {
+                "name": "path",
+                "type": "path",
+                "example": "/retroarch",
+                "default": "/retroarch"
             },
             {
                 "name": "is_public",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Emulate videogames system and play videogames through your web browser... and more!",
         "fr": "Emulez des consoles de jeux et jouer à ces jeux vidéos dans votre explorateur web... Et beaucoup plus!"
     },
-    "version": "1.9.2~ynh1",
+    "version": "1.9.2~ynh2",
     "url": "http://www.retroarch.com/",
     "license": "GPL-3.0-or-later",
     "maintainer": {

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -6,9 +6,8 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source /usr/share/yunohost/helpers
 source _common.sh
-
+source /usr/share/yunohost/helpers
 
 #=================================================
 # RETRIEVE ARGUMENTS
@@ -30,11 +29,15 @@ ynh_script_progression --message="Loading installation settings..." --time --wei
 # Needed for helper "ynh_add_nginx_config"
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
+# Add settings here as needed by your application
+#db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+#db_user=$db_name
+#db_pwd=$(ynh_app_setting_get --app=$app --key=db_pwd)
 
 #=================================================
-# BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
+# BACKUP BEFORE CHANGE URL THEN ACTIVE TRAP
 #=================================================
-ynh_script_progression --message="Backing up the app before changing its url (may take a while)..." --time --weight=1
+ynh_script_progression --message="Backing up the app before changing its URL (may take a while)..." --weight=10
 
 # Backup the current version of the app
 ynh_backup_before_upgrade
@@ -42,7 +45,7 @@ ynh_clean_setup () {
 	# Remove the new domain config file, the remove script won't do it as it doesn't know yet its location.
 	ynh_secure_remove --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
 
-	# restore it if the upgrade fails
+	# Restore it if the upgrade fails
 	ynh_restore_upgradebackup
 }
 # Exit if an error occurs during the execution of the script
@@ -61,31 +64,31 @@ fi
 change_path=0
 if [ "$old_path" != "$new_path" ]
 then
-	ynh_print_warn "RetroArch works only on root path, path cannot be changed!
-	#change_path=1
+	change_path=1
 fi
 
+#=================================================
+# STANDARD MODIFICATIONS
 #=================================================
 # MODIFY URL IN NGINX CONF
 #=================================================
-ynh_script_progression --message="Updating nginx web server configuration..." --time --weight=1
+ynh_script_progression --message="Updating NGINX web server configuration..." --time --weight=1
 
 nginx_conf_path=/etc/nginx/conf.d/$old_domain.d/$app.conf
 
-# Change the path in the nginx config file
+# Change the path in the NGINX config file
 if [ $change_path -eq 1 ]
 then
-	# Make a backup of the original nginx config file if modified
+	# Make a backup of the original NGINX config file if modified
 	ynh_backup_if_checksum_is_different --file="$nginx_conf_path"
-	# Set global variables for nginx helper
+	# Set global variables for NGINX helper
 	domain="$old_domain"
 	path_url="$new_path"
-	# Create a dedicated nginx config
+	# Create a dedicated NGINX config
 	ynh_add_nginx_config
 fi
 
-# Change the domain for nginx
-#Keep it if, one day, we can change it...
+# Change the domain for NGINX
 if [ $change_domain -eq 1 ]
 then
 	# Delete file checksum for the old conf file location
@@ -96,15 +99,11 @@ then
 fi
 
 #=================================================
-# SPECIFIC MODIFICATIONS
-#=================================================
-# ...
-#=================================================
-
+# GENERIC FINALISATION
 #=================================================
 # RELOAD NGINX
 #=================================================
-ynh_script_progression --message="Reloading nginx web server..." --time --weight=1
+ynh_script_progression --message="Reloading NGINX web server..." --time --weight=1
 
 ynh_systemd_action --service_name=nginx --action=reload
 

--- a/scripts/install
+++ b/scripts/install
@@ -25,7 +25,7 @@ ynh_abort_if_errors
 #=================================================
 
 domain=$YNH_APP_ARG_DOMAIN
-path_url="/"
+path_url=$YNH_APP_ARG_PATH
 is_public=$YNH_APP_ARG_IS_PUBLIC
 app=$YNH_APP_INSTANCE_NAME
 


### PR DESCRIPTION
## Problem
- *Since version 1.9.2, subdomain are working on retroarch web player https://github.com/libretro/RetroArch/pull/12033*

## Solution
- *Add standard nginx and manifest config*

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/retroarch_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/retroarch_ynh%20PR-NUM-%20(USERNAME)/)  
